### PR TITLE
Improve backup display

### DIFF
--- a/tklbam/index.cgi
+++ b/tklbam/index.cgi
@@ -78,7 +78,7 @@ print ui_form_start('restore.cgi', 'post');
 printf "<div style='text-align: right; padding-right: 5px'><a href='list_refresh.cgi'>%s</a></div>", text('index_list_refresh');
 
 my @hbrs = tklbam_list();
-my @this_hbr = undef;
+my @this_hbr;
 my $backup_id = get_backup_id();
 if ($backup_id) {
     @this_hbr = tklbam_list($backup_id);

--- a/tklbam/index.cgi
+++ b/tklbam/index.cgi
@@ -78,32 +78,45 @@ print ui_form_start('restore.cgi', 'post');
 printf "<div style='text-align: right; padding-right: 5px'><a href='list_refresh.cgi'>%s</a></div>", text('index_list_refresh');
 
 my @hbrs = tklbam_list();
+my @this_hbr = undef;
+my $backup_id = get_backup_id();
+if ($backup_id) {
+    @this_hbr = tklbam_list($backup_id);
+}
 
 unless(@hbrs) {
     print '<b>'.text('index_list_nobackups').'</b>';
 } else {
-    print ui_columns_start( [text('index_list_id'), hlink(text('index_list_passphrase'), 'passphrase'), 
-                             text('index_list_created'), text('index_list_updated'), 
-                             text('index_list_size'), text('index_list_label'), 
-                             text('index_list_action') ], 100, undef, $colalign);
+    my @backup_list_tabs = ( [ 'this_server', text('index_list_local') ],
+                             # [ 'this_type', text('index_list_type') ],
+                             [ 'all_backups', text('index_list_all') ] );
 
-    foreach my $hbr (@hbrs) {
-        my $id = $hbr->[0];
-        my $skpp = lc $hbr->[1];
-        print ui_columns_row([@$hbr, 
-                                ui_submit(text('index_list_action_restore'),
-                                          join(':', 'restore', $id, $skpp)) .
-                                ui_submit(text('index_list_action_options'),
-                                          join(':', 'advanced', $id, $skpp))
-                                          ], $colalign);
+    print ui_tabs_start(\@backup_list_tabs, 'list_backups', 'this_server', 0);
+
+    print ui_tabs_start_tab('list_backups', 'this_server');
+    if ($backup_id) {
+        show_backups(@this_hbr);
+    } else {
+        print "<p>No backups for this server.</p>";
+        print "<p>Please either create a backup, or select 'All backups' tab (above) to display all Hub backups.<p>";
     }
+    print ui_tabs_end_tab('list_backups', 'this_server');
 
-    print ui_columns_end();
+    #print ui_tabs_start_tab('list_backups', 'this_type');
+    #print "<p>NOT IMPLEMENTED YET</p>";
+    #print ui_tabs_end_tab('list_backups', 'this_type');
+
+    print ui_tabs_start_tab('list_backups', 'all_backups');
+    show_backups(@hbrs);
+    print ui_tabs_end_tab('list_backups', 'all_backups');
+
+    print ui_tabs_end();
 }
 
 
 print ui_form_end();
 
 print ui_tabs_end_tab('mode', 'restore');
+print ui_tabs_end();
 
 ui_print_footer('/', text('index'));

--- a/tklbam/lang/en
+++ b/tklbam/lang/en
@@ -31,6 +31,11 @@ index_rollback_timestamp=System snapshot from $1
 index_list=Backup List
 index_list_refresh=Refresh
 index_list_nobackups=No backups have yet been created
+
+index_list_local=This server
+index_list_type=Backups that match this server
+index_list_all=All backups
+
 index_list_id=ID
 index_list_passphrase=SKPP (?)
 index_list_created=Created

--- a/tklbam/restore_run.cgi
+++ b/tklbam/restore_run.cgi
@@ -90,7 +90,7 @@ if ($skpp eq 'no' or ($passphrase or $key)) {
     }
 
     if ($in{'limits'}) {
-        $limits = join(" ", split(/\s+/, $in{'limits'}));
+        my $limits = join(" ", split(/\s+/, $in{'limits'}));
         $command .= " --limits='$limits'";
     }
     $command .= " --time='$in{'time'}'" if $in{'time'};
@@ -121,4 +121,4 @@ if ($skpp eq 'no' or ($passphrase or $key)) {
     }
 }
 
-ui_print_footer('/', text'index'));
+ui_print_footer('/', text('index'));

--- a/tklbam/tklbam-lib.pl
+++ b/tklbam/tklbam-lib.pl
@@ -26,6 +26,28 @@ sub debug_log {
     print $logfile "$logmessage\n";
 }
 
+sub show_backups {
+    my @hbrs = @_;
+    my $colalign = [undef, undef, undef, undef, undef, undef, 'align="center"'];
+    print ui_columns_start(
+        [ text('index_list_id'), hlink(text('index_list_passphrase'), 'passphrase'),
+          text('index_list_created'), text('index_list_updated'),
+          text('index_list_size'), text('index_list_label'),
+          text('index_list_action') ],
+        100, undef, $colalign);
+    foreach my $hbr (@hbrs) {
+        my $id = $hbr->[0];
+        my $skpp = lc $hbr->[1];
+        print ui_columns_row([@$hbr,
+                              ui_submit(text('index_list_action_restore'),
+                              join(':', 'restore', $id, $skpp)) .
+                              ui_submit(text('index_list_action_options'),
+                              join(':', 'advanced', $id, $skpp))
+                             ], $colalign);
+    }
+    print ui_columns_end();
+}
+
 sub is_installed {
     return has_command("tklbam");
 }


### PR DESCRIPTION
Previously on the TKLBAM Webmin module landing page (`index.cgi` - the default page once TKLBAM has been initialised), within the "Restore" tab, all backups were shown.

This PR implements new sub-tabs within the "Restore" tab. "This server" is the first (and default) sub-tab. It shows only the backup from the current server. The second "All backups" tab, lists all backups (as the base "Restore" tab used to).

Closes https://github.com/turnkeylinux/tracker/issues/190

Also contains a minor bugfix for `restore_run.cgi `.